### PR TITLE
fix the 64-bit library name.

### DIFF
--- a/lib/sybase/lib.rb
+++ b/lib/sybase/lib.rb
@@ -5,7 +5,7 @@ module Sybase
     suffix = RUBY_VERSION < '1.9' ? '' : '_r'
 
     if FFI.type_size(:pointer) == 8
-      ffi_lib "sybct64#{suffix}"
+      ffi_lib "sybct#{suffix}64"
     else
       ffi_lib "sybct#{suffix}"
     end


### PR DESCRIPTION
The 64-bit libraries are libsybct64.so and libsybct_r64.so.
